### PR TITLE
Handle multiple versions of Xcode for 4.x releases

### DIFF
--- a/Bench-Swift/lib/install-swift.sh
+++ b/Bench-Swift/lib/install-swift.sh
@@ -5,6 +5,7 @@ function installSwift {
   # -s flag (skip-existing) prevents failure when build already installed
   local version=`cat .swift-version`
   local swiftMajor=`echo $version | cut -d'.' -f1`
+  local swiftMinor=`echo $version | cut -d'.' -f2`
   case `uname` in
   Linux)
     swiftenv install $version -s
@@ -15,7 +16,9 @@ function installSwift {
 
     # Ensure we select the correct XCode version for this version of swift:
     #   Swift 3.x = XCode 8.3
-    #   Swift 4.x = XCode 9
+    #   Swift 4.0.x = XCode 9.2
+    #   Swift 4.1.x = XCode 9.4
+    #   Swift 4.2.x = XCode 10
     #
     # Note that this relies on having previous versions of XCode installed in a
     # prescribed location (example: /Applications/Xcode8.3.3).
@@ -23,12 +26,26 @@ function installSwift {
     case "$swiftMajor" in
     3)
       echo "Switching to Xcode 8.3.3 for Swift 3.x"
-      sudo xcode-select -s /Applications/Xcode8.3.3.app/Contents/Developer
+      sudo xcode-select -s /Applications/Xcode8.3.3.app
       xcode-select -p
       ;;
     4)
-      echo "Switching to Xcode 9 for Swift 4.x"
-      sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+      case "$swiftMinor" in
+      0)
+        echo "Switching to Xcode 9.2 for Swift 4.0.x"
+        sudo xcode-select -s /Applications/Xcode9.2.app
+        ;;
+      1)
+        echo "Switching to Xcode 9.4 for Swift 4.1.x"
+        sudo xcode-select -s /Applications/Xcode9.4.app
+        ;;
+      2)
+        echo "Switching to Xcode 10.0 for Swift 4.2.x"
+        sudo xcode-select -s /Applications/Xcode10.0.app
+        ;;
+      *)
+        echo "Unknown Swift 4 minor version: ${swiftMinor}"
+      esac
       xcode-select -p
       ;;
     *)

--- a/Bench-Swift/lib/install-swift.sh
+++ b/Bench-Swift/lib/install-swift.sh
@@ -26,31 +26,39 @@ function installSwift {
     case "$swiftMajor" in
     3)
       echo "Switching to Xcode 8.3.3 for Swift 3.x"
-      sudo xcode-select -s /Applications/Xcode8.3.3.app
-      xcode-select -p
+      switchXcodeIfAvailable /Applications/Xcode8.3.3.app
       ;;
     4)
       case "$swiftMinor" in
       0)
         echo "Switching to Xcode 9.2 for Swift 4.0.x"
-        sudo xcode-select -s /Applications/Xcode9.2.app
+        switchXcodeIfAvailable /Applications/Xcode9.2.app
         ;;
       1)
         echo "Switching to Xcode 9.4 for Swift 4.1.x"
-        sudo xcode-select -s /Applications/Xcode9.4.app
+        switchXcodeIfAvailable /Applications/Xcode9.4.app
         ;;
       2)
         echo "Switching to Xcode 10.0 for Swift 4.2.x"
-        sudo xcode-select -s /Applications/Xcode10.0.app
+        switchXcodeIfAvailable /Applications/Xcode10.0.app
         ;;
       *)
         echo "Unknown Swift 4 minor version: ${swiftMinor}"
       esac
-      xcode-select -p
       ;;
     *)
       echo "Unknown Swift major version: $swiftMajor"
     esac
+    echo "Selected Xcode installation: `xcode-select -p`"
     ;;
   esac
+}
+
+function switchXcodeIfAvailable {
+  local xcodePath="$1"
+  if [ -d "$xcodePath" ]; then
+    sudo xcode-select -s $xcodePath
+  else
+    echo "No Xcode installation found at $xcodePath"
+  fi
 }


### PR DESCRIPTION
Swift 4.0.3 and 4.1.2 require different versions of Xcode when running the benchmarks on macOS.  This is easy to handle with Travis (as we just specify the appropriate xcode image), but on a 'normal' system it requires multiple installs of Xcode and use of `xcode-select` to pick the right version corresponding to the Swift SDK.

This PR updates the `install-swift.sh` helper to handle each version of Swift 4.x.  It assumes that the machine owner has installed Xcode with a particular naming convention:
- `/Applications/Xcode8.3.3` for Swift 3.x
- `/Applications/Xcode9.2` for Swift 4.0.x
- `/Applications/Xcode9.4` for Swift 4.1.x
- `/Applications/Xcode10.0` for Swift 4.2.x (planning ahead)

I've updated the installs on the test machines that I use to match this naming convention.