### PR TITLE
Update .gitignore

### DIFF
--- a/Bench-Kitura-Blog/.gitignore
+++ b/Bench-Kitura-Blog/.gitignore
@@ -38,6 +38,7 @@ playground.xcworkspace
 Packages/
 .build/
 .build_gcd/
+Package.resolved
 
 # CocoaPods
 #
@@ -70,8 +71,8 @@ fastlane/test_output
 perf.data
 perf.data.old
 
-# Check out of dependent projects
-bench/
+# Symlink to Bench-Swift
+bench
 
 # Our custom build / benchmark artefacts
 baselineBuild/

--- a/Bench-Kitura-Core/.gitignore
+++ b/Bench-Kitura-Core/.gitignore
@@ -38,6 +38,7 @@ playground.xcworkspace
 Packages/
 .build/
 .build_gcd/
+Package.resolved
 
 # CocoaPods
 #
@@ -70,8 +71,8 @@ fastlane/test_output
 perf.data
 perf.data.old
 
-# Check out of dependent projects
-bench/
+# Symlink to Bench-Swift
+bench
 
 # Our custom build / benchmark artefacts
 baseline/

--- a/Bench-Kitura-SwiftMetrics/.gitignore
+++ b/Bench-Kitura-SwiftMetrics/.gitignore
@@ -38,6 +38,7 @@ playground.xcworkspace
 Packages/
 .build/
 .build_gcd/
+Package.resolved
 
 # CocoaPods
 #
@@ -70,8 +71,8 @@ fastlane/test_output
 perf.data
 perf.data.old
 
-# Check out of dependent projects
-bench/
+# Symlink to Bench-Swift
+bench
 
 # Our custom build / benchmark artefacts
 baselineBuild/

--- a/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorld/main.swift
+++ b/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorld/main.swift
@@ -15,7 +15,6 @@
  */
 
 import Kitura
-import SwiftyJSON
 import LoggerAPI
 import HeliumLogger
 import Foundation

--- a/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorldSwiftMetrics/main.swift
+++ b/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorldSwiftMetrics/main.swift
@@ -15,7 +15,6 @@
  */
 
 import Kitura
-import SwiftyJSON
 import LoggerAPI
 import HeliumLogger
 import Foundation

--- a/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorldSwiftMetricsHTTP/main.swift
+++ b/Bench-Kitura-SwiftMetrics/latest/Sources/HelloWorldSwiftMetricsHTTP/main.swift
@@ -15,7 +15,6 @@
  */
 
 import Kitura
-import SwiftyJSON
 import LoggerAPI
 import HeliumLogger
 import Foundation

--- a/Bench-Kitura-TechEmpower/.gitignore
+++ b/Bench-Kitura-TechEmpower/.gitignore
@@ -38,6 +38,7 @@ playground.xcworkspace
 Packages/
 .build/
 .build_gcd/
+Package.resolved
 
 # CocoaPods
 #
@@ -70,8 +71,8 @@ fastlane/test_output
 perf.data
 perf.data.old
 
-# Check out of dependent projects
-bench/
+# Symlink to Bench-Swift
+bench
 
 # Our custom build / benchmark artefacts
 baseline/


### PR DESCRIPTION
Updates the `.gitignore` files since we replaced the `bench` checkout with a symlink, and also ignores `Package.resolved` which is generated when the projects are built with Swift 4.