### PR TITLE
Add KituraNIO builds and testing to performance benchmarks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ language: java
 # Install prereqs (linux deps, swiftenv, wrk, jmeter)
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install bc libhttp-date-perl clang libicu-dev libcurl4-openssl-dev libssl-dev libpython2.7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl; fi
   - git clone https://github.com/kylef/swiftenv.git ~/.swiftenv && export SWIFTENV_ROOT="$HOME/.swiftenv" && export PATH="$SWIFTENV_ROOT/bin:$PATH" && eval "$(swiftenv init -)"
   - git clone https://github.com/djones6/wrk -b interval && cd wrk && make > build.out && export PATH="$PWD:$PATH" && cd ..
   - git clone https://github.com/apache/jmeter.git -b v2_13 && export PATH="$PWD/jmeter/bin:$PATH" 
   - if [[ -n "$SWIFT_VERSION" ]]; then swiftenv install $SWIFT_VERSION -s; fi
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,3 +104,4 @@ before_install:
   - git clone https://github.com/djones6/wrk -b interval && cd wrk && make > build.out && export PATH="$PWD:$PATH" && cd ..
   - git clone https://github.com/apache/jmeter.git -b v2_13 && export PATH="$PWD/jmeter/bin:$PATH" 
   - if [[ -n "$SWIFT_VERSION" ]]; then swiftenv install $SWIFT_VERSION -s; fi
+

--- a/Bench-Kitura-Blog/build.sh
+++ b/Bench-Kitura-Blog/build.sh
@@ -31,13 +31,18 @@ Darwin)
   ;;
 esac
 
+echo "Swift build flags: $SWIFT_BUILD_FLAGS"
+
 # Build 'new' version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+export KITURA_NIO=1
+build "$dir/nio" "$REPO" "$NEW_COMMIT"
 popd
 
 # Build 'baseline' version
 pushd $dir/${BASE_VERSION}/
 build "$dir/baselineBuild"
 popd
+

--- a/Bench-Kitura-Blog/build.sh
+++ b/Bench-Kitura-Blog/build.sh
@@ -31,18 +31,34 @@ Darwin)
   ;;
 esac
 
-echo "Swift build flags: $SWIFT_BUILD_FLAGS"
-
-# Build 'new' version
+# Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
+
+function cloneProject {
+  local projectPath=$1
+  local newPath=$2
+  pushd $projectPath
+  swift package reset
+  popd
+  if [ -d $newPath ]; then
+    preserveDir $newPath
+  fi
+  cp -R -p $projectPath $newPath
+}
+
+cloneProject $dir/latest $dir/latest-nio
+
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+popd
+
+pushd $dir/latest-nio/
 export KITURA_NIO=1
-build "$dir/nio" "$REPO" "$NEW_COMMIT"
+build "$dir/nioBuild" "$REPO" "$NEW_COMMIT"
+unset KITURA_NIO
 popd
 
 # Build 'baseline' version
 pushd $dir/${BASE_VERSION}/
 build "$dir/baselineBuild"
 popd
-

--- a/Bench-Kitura-Blog/build.sh
+++ b/Bench-Kitura-Blog/build.sh
@@ -34,18 +34,6 @@ esac
 # Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 
-function cloneProject {
-  local projectPath=$1
-  local newPath=$2
-  pushd $projectPath
-  swift package reset
-  popd
-  if [ -d $newPath ]; then
-    preserveDir $newPath
-  fi
-  cp -R -p $projectPath $newPath
-}
-
 cloneProject $dir/latest $dir/latest-nio
 
 pushd $dir/latest/

--- a/Bench-Kitura-Core/build.sh
+++ b/Bench-Kitura-Core/build.sh
@@ -34,18 +34,6 @@ esac
 # Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 
-function cloneProject {
-  local projectPath=$1
-  local newPath=$2
-  pushd $projectPath
-  swift package reset
-  popd
-  if [ -d $newPath ]; then
-    preserveDir $newPath
-  fi
-  cp -R -p $projectPath $newPath
-}
-
 cloneProject $dir/latest $dir/latest-nio
 
 pushd $dir/latest/

--- a/Bench-Kitura-Core/build.sh
+++ b/Bench-Kitura-Core/build.sh
@@ -30,14 +30,32 @@ Darwin)
   SWIFT_BUILD_FLAGS=""
   ;;
 esac
-echo "Swift Build Flags: $SWIFT_BUILD_FLAGS"
-# Build 'new' version
+
+# Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
+
+function cloneProject {
+  local projectPath=$1
+  local newPath=$2
+  pushd $projectPath
+  swift package reset
+  popd
+  if [ -d $newPath ]; then
+    preserveDir $newPath
+  fi
+  cp -R -p $projectPath $newPath
+}
+
+cloneProject $dir/latest $dir/latest-nio
+
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
-#Build 'nio' version
+popd
+
+pushd $dir/latest-nio/
 export KITURA_NIO=1
-build "$dir/nio" "$REPO" "$NEW_COMMIT"
+build "$dir/nioBuild" "$REPO" "$NEW_COMMIT"
+unset KITURA_NIO
 popd
 
 # Build 'baseline' version

--- a/Bench-Kitura-Core/build.sh
+++ b/Bench-Kitura-Core/build.sh
@@ -30,11 +30,14 @@ Darwin)
   SWIFT_BUILD_FLAGS=""
   ;;
 esac
-
+echo "Swift Build Flags: $SWIFT_BUILD_FLAGS"
 # Build 'new' version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+#Build 'nio' version
+export KITURA_NIO=1
+build "$dir/nio" "$REPO" "$NEW_COMMIT"
 popd
 
 # Build 'baseline' version

--- a/Bench-Kitura-SwiftMetrics/build.sh
+++ b/Bench-Kitura-SwiftMetrics/build.sh
@@ -30,11 +30,13 @@ Darwin)
   SWIFT_BUILD_FLAGS=""
   ;;
 esac
-
+echo "Swift build flags: $SWIFT_BUILD_FLAGS"
 # Build 'new' version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+export KITURA_NIO=1
+build "$dir/nio" "$REPO" "$NEW_COMMIT"
 popd
 
 # Build 'baseline' version

--- a/Bench-Kitura-SwiftMetrics/build.sh
+++ b/Bench-Kitura-SwiftMetrics/build.sh
@@ -34,18 +34,6 @@ esac
 # Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 
-function cloneProject {
-  local projectPath=$1
-  local newPath=$2
-  pushd $projectPath
-  swift package reset
-  popd
-  if [ -d $newPath ]; then
-    preserveDir $newPath
-  fi
-  cp -R -p $projectPath $newPath
-}
-
 cloneProject $dir/latest $dir/latest-nio
 
 pushd $dir/latest/

--- a/Bench-Kitura-SwiftMetrics/build.sh
+++ b/Bench-Kitura-SwiftMetrics/build.sh
@@ -30,13 +30,32 @@ Darwin)
   SWIFT_BUILD_FLAGS=""
   ;;
 esac
-echo "Swift build flags: $SWIFT_BUILD_FLAGS"
-# Build 'new' version
+
+# Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
+
+function cloneProject {
+  local projectPath=$1
+  local newPath=$2
+  pushd $projectPath
+  swift package reset
+  popd
+  if [ -d $newPath ]; then
+    preserveDir $newPath
+  fi
+  cp -R -p $projectPath $newPath
+}
+
+cloneProject $dir/latest $dir/latest-nio
+
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+popd
+
+pushd $dir/latest-nio/
 export KITURA_NIO=1
-build "$dir/nio" "$REPO" "$NEW_COMMIT"
+build "$dir/nioBuild" "$REPO" "$NEW_COMMIT"
+unset KITURA_NIO 
 popd
 
 # Build 'baseline' version

--- a/Bench-Kitura-SwiftMetrics/latest/Package.swift
+++ b/Bench-Kitura-SwiftMetrics/latest/Package.swift
@@ -8,7 +8,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),
+        //Switch back to the latest release of SwiftMetrics once the tagging is done
+        //.package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),
+        .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", .branch("bd5832af20c284093180ba40e4ca5e160d88820c")),
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.0.0"),
     ],

--- a/Bench-Kitura-SwiftMetrics/latest/Package.swift
+++ b/Bench-Kitura-SwiftMetrics/latest/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        //Switch back to the latest release of SwiftMetrics once the tagging is done
+        //Switch back to the latest release of SwiftMetrics once tagging is done
         //.package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),
         .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", .branch("bd5832af20c284093180ba40e4ca5e160d88820c")),
         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.0.0"),

--- a/Bench-Kitura-TechEmpower/build.sh
+++ b/Bench-Kitura-TechEmpower/build.sh
@@ -34,18 +34,6 @@ esac
 # Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 
-function cloneProject {
-  local projectPath=$1
-  local newPath=$2
-  pushd $projectPath
-  swift package reset
-  popd
-  if [ -d $newPath ]; then
-    preserveDir $newPath
-  fi
-  cp -R -p $projectPath $newPath
-}
-
 cloneProject $dir/latest $dir/latest-nio
 
 pushd $dir/latest/

--- a/Bench-Kitura-TechEmpower/build.sh
+++ b/Bench-Kitura-TechEmpower/build.sh
@@ -31,13 +31,31 @@ Darwin)
   ;;
 esac
 
-echo "Swift build flags: $SWIFT_BUILD_FLAGS"
-# Build 'new' version
+# Build 'new' and "nio" version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
+
+function cloneProject {
+  local projectPath=$1
+  local newPath=$2
+  pushd $projectPath
+  swift package reset
+  popd
+  if [ -d $newPath ]; then
+    preserveDir $newPath
+  fi
+  cp -R -p $projectPath $newPath
+}
+
+cloneProject $dir/latest $dir/latest-nio
+
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
-#Build 'nio' version
-build "$dir/nio" "$REPO" "$NEW_COMMIT"
+popd
+
+pushd $dir/latest-nio/
+export KITURA_NIO=1
+build "$dir/nioBuild" "$REPO" "$NEW_COMMIT"
+unset KITURA_NIO
 popd
 
 # Build 'baseline' version

--- a/Bench-Kitura-TechEmpower/build.sh
+++ b/Bench-Kitura-TechEmpower/build.sh
@@ -31,10 +31,13 @@ Darwin)
   ;;
 esac
 
+echo "Swift build flags: $SWIFT_BUILD_FLAGS"
 # Build 'new' version
 # If $REPO and $NEW_COMMIT are set, edit package $REPO to $NEW_COMMIT before building
 pushd $dir/latest/
 build "$dir/newBuild" "$REPO" "$NEW_COMMIT"
+#Build 'nio' version
+build "$dir/nio" "$REPO" "$NEW_COMMIT"
 popd
 
 # Build 'baseline' version

--- a/Bench-Swift/lib/bench.sh
+++ b/Bench-Swift/lib/bench.sh
@@ -120,7 +120,7 @@ function runBenchmark {
       ;;
     *)
       # Execute a 2-way compare of baseline and new build for the same implementation
-      $dir/bench/compare.sh $dir/baselineBuild/release/${IMPLEMENTATION},label=Baseline,pwd=$dir $dir/newBuild/release/${IMPLEMENTATION},label=New,pwd=$dir
+      $dir/bench/compare.sh $dir/baselineBuild/release/${IMPLEMENTATION},label=Baseline,pwd=$dir $dir/newBuild/release/${IMPLEMENTATION},label=New,pwd=$dir $dir/nioBuild/release/${IMPLEMENTATION},label=Nio,pwd=$dir
       ;;
     esac
 

--- a/Bench-Swift/lib/build.sh
+++ b/Bench-Swift/lib/build.sh
@@ -10,8 +10,8 @@ BUILD_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function cloneProject {
   local projectPath=$1
   local newPath=$2
-  installSwift
   cd $projectPath
+  installSwift
   swift package reset
   if [ -d $newPath ]; then
     preserveDir $newPath

--- a/Bench-Swift/lib/build.sh
+++ b/Bench-Swift/lib/build.sh
@@ -6,6 +6,21 @@ BUILD_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # import install Swift function
 . $BUILD_SCRIPT_DIR/install-swift.sh
 
+#Copies a project to another project
+function cloneProject {
+  local projectPath=$1
+  local newPath=$2
+  installSwift
+  cd $projectPath
+  swift package reset
+  if [ -d $newPath ]; then
+    preserveDir $newPath
+  fi
+  cd -
+  cp -R -p $projectPath $newPath
+}
+
+
 #
 # Builds a Swift project.
 #


### PR DESCRIPTION
Currently, the Kitura-Benchmarks are built and run for Kitura with Kitura-net. This PR enables Kitura to switch to Kitura-NIO and a new build called the 'nioBuild' is generated and the performance benchmarks are run and results are stored under the new label 'Nio'. 

