### PR TITLE
fix: Use lowercase column and table names for Postgres

### DIFF
--- a/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerKuery/Postgres.swift
+++ b/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerKuery/Postgres.swift
@@ -41,14 +41,14 @@ let dbRows = 10000
 let maxValue = 10000
 
 class World: Table {
-    let tableName = "World"
+    let tableName = "world"
     
     let id = Column("id")
-    let randomNumber = Column("randomNumber")
+    let randomNumber = Column("randomnumber")
 }
 
 class Fortunes: Table {
-    let tableName = "Fortune"
+    let tableName = "fortune"
 
     let id = Column("id")
     let message = Column("message")

--- a/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerKueryMustache/Postgres.swift
+++ b/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerKueryMustache/Postgres.swift
@@ -41,14 +41,14 @@ let dbRows = 10000
 let maxValue = 10000
 
 class World: Table {
-    let tableName = "World"
+    let tableName = "world"
     
     let id = Column("id")
-    let randomNumber = Column("randomNumber")
+    let randomNumber = Column("randomnumber")
 }
 
 class Fortunes: Table {
-    let tableName = "Fortune"
+    let tableName = "fortune"
 
     let id = Column("id")
     let message = Column("message")


### PR DESCRIPTION
[Swift-Kuery-PostgreSQL 1.2](https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL/releases/tag/1.2.0) introduces case sensitivity for table and column names, as names are now quoted (rather than being implicitly lowercased by the database).

As a result, the table and column definitions in these benchmarks need to be explicitly lowercased in order to match the database schema.

Only the 'latest' version needs this change, since the baseline versions explicitly depend on a 1.x version of Kuery.