### PR TITLE
TechEmpower async fixes

### DIFF
--- a/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerPostgres/main.swift
+++ b/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerPostgres/main.swift
@@ -53,7 +53,7 @@ router.add(templateEngine: StencilTemplateEngine(extension: ext))
 router.get("/db") {
     request, response, next in
     response.headers["Server"] = "Kitura"
-    getRandomRow { (row, err) in
+    getRandomRow_Raw { (row, err) in
         guard let row = row else {
             guard let err = err else {
                 Log.error("Unknown Error")
@@ -77,38 +77,47 @@ router.get("/queries") {
     response.headers["Server"] = "Kitura"
     let queriesParam = request.queryParameters["queries"] ?? "1"
     let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
+    getRandomRows_Raw(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
+        }
+    }
+}
+
+router.get("/queriesParallel") {
+    request, response, next in
+    response.headers["Server"] = "Kitura"
+    let queriesParam = request.queryParameters["queries"] ?? "1"
+    let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
     var results: [[String:Int]] = []
-    // Used to track completion of concurrent queries
-    let resultNotification = DispatchSemaphore(value: 0)
     // Used to protect result array from concurrent modification
     let updateLock = DispatchSemaphore(value: 1)
     // Execute each query. Each callback will append its result to `results`
     for _ in 1...numQueries {
-        getRandomRow { (row, err) in
+        getRandomRow_Raw { (row, err) in
             guard let row = row else {
                 guard let err = err else {
                     Log.error("Unknown Error")
-                    resultNotification.signal()
                     try? response.status(.badRequest).send("Unknown error").end()
                     return
                 }
                 Log.error("\(err)")
-                resultNotification.signal()
                 try? response.status(.badRequest).send("Error: \(err)").end()
                 return
             }
             updateLock.wait()
             results.append(row.asDictionary())
+            if results.count == numQueries {
+                // Return JSON representation of array of results
+                try? response.status(.OK).send(json: results).end()
+            }
             updateLock.signal()
-            resultNotification.signal()
         }
     }
-    // Wait for all callbacks to complete
-    for _ in 1...numQueries {
-        resultNotification.wait()
-    }
-    // Return JSON representation of array of results
-    try response.status(.OK).send(json: results).end()
 }
 
 //
@@ -146,45 +155,55 @@ router.get("/updates") {
     response.headers["Server"] = "Kitura"
     let queriesParam = request.queryParameters["queries"] ?? "1"
     let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
+    updateRandomRows_Raw(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
+        }
+    }
+}
+
+
+router.get("/updatesParallel") {
+    request, response, next in
+    response.headers["Server"] = "Kitura"
+    let queriesParam = request.queryParameters["queries"] ?? "1"
+    let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
     var results: [[String:Int]] = []
-    // Used to track completion of concurrent queries
-    let resultNotification = DispatchSemaphore(value: 0)
     // Used to protect result array from concurrent modification
     let updateLock = DispatchSemaphore(value: 1)
     // Execute each query. Each callback will append its result to `results`
     for _ in 1...numQueries {
-        getRandomRow { (row, err) in
+        getRandomRow_Raw { (row, err) in
             guard let row = row else {
                 guard let err = err else {
                     Log.error("Unknown Error")
-                    resultNotification.signal()
                     try? response.status(.badRequest).send("Unknown error").end()
                     return
                 }
                 Log.error("\(err)")
-                resultNotification.signal()
                 try? response.status(.badRequest).send("Error: \(err)").end()
                 return
             }
             // Execute inner callback for updating the row
-            updateRow(id: row.id) { (err) in
+            updateRow_Raw(id: row.id) { (err) in
                 if let err = err {
-                    resultNotification.signal()
                     try? response.status(.badRequest).send("Error: \(err)").end()
                     return
                 }
                 updateLock.wait()
                 results.append(row.asDictionary())
+                if results.count == numQueries {
+                    // Return JSON representation of array of results
+                    try? response.status(.OK).send(json: results).end()
+                }
                 updateLock.signal()
-                resultNotification.signal()
             }
         }
     }
-    for _ in 1...numQueries {
-        resultNotification.wait()
-    }
-    // Return JSON representation of array of results
-    try response.status(.OK).send(json: results).end()
 }
 
 

--- a/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerPostgresORM/main.swift
+++ b/Bench-Kitura-TechEmpower/latest/Sources/TechEmpowerPostgresORM/main.swift
@@ -79,38 +79,31 @@ router.get("/queries") {
     response.headers["Server"] = "Kitura"
     let queriesParam = request.queryParameters["queries"] ?? "1"
     let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
-    var results: [[String:Int]] = []
-    // Used to track completion of concurrent queries
-    let resultNotification = DispatchSemaphore(value: 0)
-    // Used to protect result array from concurrent modification
-    let updateLock = DispatchSemaphore(value: 1)
-    // Execute each query. Each callback will append its result to `results`
-    for _ in 1...numQueries {
-        getRandomRow { (row, err) in
-            guard let row = row else {
-                guard let err = err else {
-                    Log.error("Unknown Error")
-                    resultNotification.signal()
-                    try? response.status(.badRequest).send("Unknown error").end()
-                    return
-                }
-                Log.error("\(err)")
-                resultNotification.signal()
-                try? response.status(.badRequest).send("Error: \(err)").end()
-                return
-            }
-            updateLock.wait()
-            results.append(row.asDictionary())
-            updateLock.signal()
-            resultNotification.signal()
+    getRandomRows(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
         }
     }
-    // Wait for all callbacks to complete
-    for _ in 1...numQueries {
-        resultNotification.wait()
+}
+
+router.get("/queriesParallel") {
+    request, response, next in
+    response.headers["Server"] = "Kitura"
+    let queriesParam = request.queryParameters["queries"] ?? "1"
+    let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
+    getRandomRowsParallel(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
+        }
     }
-    // Return JSON representation of array of results
-    try response.status(.OK).send(json: results).end()
 }
 
 //
@@ -142,45 +135,31 @@ router.get("/updates") {
     response.headers["Server"] = "Kitura"
     let queriesParam = request.queryParameters["queries"] ?? "1"
     let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
-    var results: [[String:Int]] = []
-    // Used to track completion of concurrent queries
-    let resultNotification = DispatchSemaphore(value: 0)
-    // Used to protect result array from concurrent modification
-    let updateLock = DispatchSemaphore(value: 1)
-    // Execute each query. Each callback will append its result to `results`
-    for _ in 1...numQueries {
-        getRandomRow { (row, err) in
-            guard let row = row else {
-                guard let err = err else {
-                    Log.error("Unknown Error")
-                    resultNotification.signal()
-                    try? response.status(.badRequest).send("Unknown error").end()
-                    return
-                }
-                Log.error("\(err)")
-                resultNotification.signal()
-                try? response.status(.badRequest).send("Error: \(err)").end()
-                return
-            }
-            // Execute inner callback for updating the row
-            updateRow(id: row.id) { (err) in
-                if let err = err {
-                    resultNotification.signal()
-                    try? response.status(.badRequest).send("Error: \(err)").end()
-                    return
-                }
-                updateLock.wait()
-                results.append(row.asDictionary())
-                updateLock.signal()
-                resultNotification.signal()
-            }
+    updateRandomRows(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
         }
     }
-    for _ in 1...numQueries {
-        resultNotification.wait()
+}
+
+router.get("/updatesParallel") {
+    request, response, next in
+    response.headers["Server"] = "Kitura"
+    let queriesParam = request.queryParameters["queries"] ?? "1"
+    let numQueries = max(1, min(Int(queriesParam) ?? 1, 500))      // Snap to range of 1-500 as per test spec
+    updateRandomRowsParallel(count: numQueries) { (rows, err) in
+        if let rows = rows {
+            try? response.status(.OK).send(json: rows).end()
+        } else if let err = err {
+            try? response.status(.badRequest).send("Error: \(err)").end()
+        } else {
+            fatalError("Unexpected: rows and err both nil")
+        }
     }
-    // Return JSON representation of array of results
-    try response.status(.OK).send(json: results).end()
 }
 
 


### PR DESCRIPTION
The TechEmpower implementation has two approaches to handling the 'N queries' requests: either perform the requests sequentially, or do them all in parallel and wait for all to complete before returning the result.

The Codable implementation had these two methods separated into `/queries` and `/queriesParallel` (and similarly for `/updates`), but this had not been done for the ORM (raw routes) and raw Kuery versions of the benchmark.

This PR presents the equivalent sequential and parallel versions of these routes for each of the Raw, ORM and Codable implementations.

It also removes an unnecessary semaphore from the parallel implementations which blocked a thread until all the parallel queries had completed.  Instead, the thread that finds that it has just appended the final result is responsible for sending back the completed response.

This code has already been delivered to the frameworkbenchmarks project via https://github.com/TechEmpower/FrameworkBenchmarks/pull/4173