### PR TITLE
Query params benchmark

### DIFF
--- a/Bench-Kitura-Core/2.3.2/Package.swift
+++ b/Bench-Kitura-Core/2.3.2/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "HelloWorld",   dependencies: benchmarkDependencies),
-        .target(name: "QueryParams",   dependencies: benchmarkDependencies),
+        .target(name: "QueryParams",  dependencies: benchmarkDependencies),
         .target(name: "HelloLogging", dependencies: benchmarkDependencies),
         .target(name: "HelloSSL",     dependencies: benchmarkDependencies),
         .target(name: "JSON",         dependencies: benchmarkDependencies),

--- a/Bench-Kitura-Core/2.3.2/Package.swift
+++ b/Bench-Kitura-Core/2.3.2/Package.swift
@@ -59,6 +59,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "HelloWorld",   dependencies: benchmarkDependencies),
+        .target(name: "QueryParams",   dependencies: benchmarkDependencies),
         .target(name: "HelloLogging", dependencies: benchmarkDependencies),
         .target(name: "HelloSSL",     dependencies: benchmarkDependencies),
         .target(name: "JSON",         dependencies: benchmarkDependencies),

--- a/Bench-Kitura-Core/2.3.2/Sources/QueryParams/main.swift
+++ b/Bench-Kitura-Core/2.3.2/Sources/QueryParams/main.swift
@@ -1,0 +1,40 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Kitura
+import LoggerAPI
+import HeliumLogger
+import Foundation
+
+Log.logger = HeliumLogger(.info)
+
+let port = Int(ProcessInfo.processInfo.environment["PORT"] ?? "8080") ?? 8080
+
+let router = Router()
+
+//
+// Plaintext echo of 'message' query parameter
+//
+router.get("/echo") {
+request, response, next in
+    let echo = request.queryParameters["message"] ?? "Supply a message using ?message=foo"
+    response.headers["Content-Type"] = "text/plain"
+    response.status(.OK).send(echo)
+    try response.end()
+}
+
+Kitura.addHTTPServer(onPort: port, with: router)
+Kitura.run()

--- a/Bench-Kitura-Core/benchmarks.sh
+++ b/Bench-Kitura-Core/benchmarks.sh
@@ -132,6 +132,9 @@ function setParams {
       # Add an Accept header to trigger Media Type processing
       WRK_SCRIPT="$dir/payloads/simpleStructPayload_accept.lua"
       ;;
+    QueryParams)
+      URL="http://localhost:8080/echo?message=foo"
+      ;;
     *)
       echo "Unknown test '$TESTNAME'"
       ;;

--- a/Bench-Kitura-Core/latest/Package.swift
+++ b/Bench-Kitura-Core/latest/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "HelloWorld",   dependencies: benchmarkDependencies),
+        .target(name: "QueryParams",   dependencies: benchmarkDependencies),
         .target(name: "HelloLogging", dependencies: benchmarkDependencies),
         .target(name: "HelloSSL",     dependencies: benchmarkDependencies),
         .target(name: "JSON",         dependencies: benchmarkDependencies),

--- a/Bench-Kitura-Core/latest/Package.swift
+++ b/Bench-Kitura-Core/latest/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "HelloWorld",   dependencies: benchmarkDependencies),
-        .target(name: "QueryParams",   dependencies: benchmarkDependencies),
+        .target(name: "QueryParams",  dependencies: benchmarkDependencies),
         .target(name: "HelloLogging", dependencies: benchmarkDependencies),
         .target(name: "HelloSSL",     dependencies: benchmarkDependencies),
         .target(name: "JSON",         dependencies: benchmarkDependencies),

--- a/Bench-Kitura-Core/latest/Sources/QueryParams/main.swift
+++ b/Bench-Kitura-Core/latest/Sources/QueryParams/main.swift
@@ -1,0 +1,40 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Kitura
+import LoggerAPI
+import HeliumLogger
+import Foundation
+
+Log.logger = HeliumLogger(.info)
+
+let port = Int(ProcessInfo.processInfo.environment["PORT"] ?? "8080") ?? 8080
+
+let router = Router()
+
+//
+// Plaintext echo of 'message' query parameter
+//
+router.get("/plaintext") {
+request, response, next in
+    let echo = request.queryParameters["message"] ?? "Supply a message using ?message=foo"
+    response.headers["Content-Type"] = "text/plain"
+    response.status(.OK).send(echo)
+    try response.end()
+}
+
+Kitura.addHTTPServer(onPort: port, with: router)
+Kitura.run()

--- a/Bench-Kitura-Core/latest/Sources/QueryParams/main.swift
+++ b/Bench-Kitura-Core/latest/Sources/QueryParams/main.swift
@@ -28,7 +28,7 @@ let router = Router()
 //
 // Plaintext echo of 'message' query parameter
 //
-router.get("/plaintext") {
+router.get("/echo") {
 request, response, next in
     let echo = request.queryParameters["message"] ?? "Supply a message using ?message=foo"
     response.headers["Content-Type"] = "text/plain"


### PR DESCRIPTION
This adds a simple benchmark which exercises query parameters (echoing back a supplied message).  It purposefully does little else in order to evaluate the performance overhead compared to a static 'Hello World' plaintext response.