### PR TITLE
[WIP] Add BSON to CodableRouting benchmark

### DIFF
--- a/Bench-Kitura-Core/latest/Package.swift
+++ b/Bench-Kitura-Core/latest/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 
 var benchmarkDependencies: [Target.Dependency] = [
 	.byNameItem(name: "Kitura"),
-	.byNameItem(name: "HeliumLogger")
+	.byNameItem(name: "HeliumLogger"),
+.byNameItem(name: "BSON"),
 ]
 
 let package = Package(
@@ -17,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.0.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-Compression.git", from: "2.1.1"),
+	.package(url: "https://github.com/OpenKitten/BSON.git", from: "5.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Bench-Kitura-Core/payloads/bsonHelloWorld.lua
+++ b/Bench-Kitura-Core/payloads/bsonHelloWorld.lua
@@ -1,0 +1,7 @@
+-- example HTTP POST script which demonstrates setting the
+-- HTTP method, body, and adding a header
+
+wrk.method = "POST"
+wrk.body   = "\27\0\0\0\2value\0\11\0\0\0Hello BSON\0\0"
+wrk.headers["Content-Type"] = "application/bson"
+wrk.headers["Accept"] = "application/bson"

--- a/Bench-Kitura-Core/payloads/jsonHelloWorld.lua
+++ b/Bench-Kitura-Core/payloads/jsonHelloWorld.lua
@@ -1,0 +1,7 @@
+-- example HTTP POST script which demonstrates setting the
+-- HTTP method, body, and adding a header
+
+wrk.method = "POST"
+wrk.body   = [[{"value":"Hello JSON"}]]
+wrk.headers["Content-Type"] = "application/json"
+wrk.headers["Accept"] = "application/json"


### PR DESCRIPTION
This PR uses OpenKitten's BSON encoder/decoder to add BSON content-type support to the CodableRouting benchmark.

Two lua scripts for `wrk` are provided, specifying a POST content-type and accept type of JSON and BSON, respectively.  These can be used to POST the structure `"value": "Hello World"` to the `/postHello` route, which then echoes the same data back again with the requested content type.

This exercises Kitura's `Content-Type` and `Accept` type determination for Codable routing (https://github.com/IBM-Swift/Kitura/pull/1309) in order to select the appropriate encoder and decoder.